### PR TITLE
Add pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ A small Flask application for managing canoe rentals. The app lets visitors book
    ```
    The application will be available at [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
-7. **Run tests (optional)**
+7. **Run tests**
+   The project includes a small test suite based on `pytest`. After installing
+   the requirements you can run all tests with:
    ```bash
-   pytest -q
+   pytest
    ```
 
 Log in to `/login` with the credentials from your `.env` file to access the admin dashboard.

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ urllib3==2.4.0
 Werkzeug==3.1.3
 wrapt==1.17.2
 WTForms==3.2.1
+pytest==8.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from main import app, db, User
+
+@pytest.fixture
+def client():
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        WTF_CSRF_ENABLED=False,
+        SECRET_KEY='test'
+    )
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username='admin')
+        admin.set_password('password')
+        db.session.add(admin)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client

--- a/tests/test_admin_crud.py
+++ b/tests/test_admin_crud.py
@@ -1,0 +1,28 @@
+from main import db, RentForm
+
+
+def login(client):
+    return client.post('/login', data={'username': 'admin', 'password': 'password'}, follow_redirects=True)
+
+
+def test_admin_crud_flow(client):
+    login(client)
+
+    # Add a booking
+    res = client.post('/admin/add', data={'name': 'Alice'}, follow_redirects=True)
+    assert res.status_code == 200
+    assert b'Alice' in res.data
+    booking = RentForm.query.filter_by(name='Alice').first()
+    assert booking is not None
+
+    # Update the booking
+    res = client.post(f'/admin/update/{booking.id}', data={'name': 'Bob'}, follow_redirects=True)
+    assert res.status_code == 200
+    assert b'Bob' in res.data
+    booking = RentForm.query.get(booking.id)
+    assert booking.name == 'Bob'
+
+    # Delete the booking
+    res = client.post(f'/admin/delete/{booking.id}', follow_redirects=True)
+    assert res.status_code == 200
+    assert RentForm.query.get(booking.id) is None

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,9 @@
+
+def test_home_page(client):
+    res = client.get('/')
+    assert res.status_code == 200
+
+
+def test_login_page(client):
+    res = client.get('/login')
+    assert res.status_code == 200


### PR DESCRIPTION
## Summary
- add pytest-based tests
- provide fixture using in-memory SQLite
- test public pages and admin CRUD flow
- explain how to run tests in README
- include pytest in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68891784ddb0832394942a02c60da719