### PR TITLE
harden default config for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,24 @@ A small Flask application for managing canoe rentals. The app lets visitors book
 4. **Configure environment variables**
    Create a `.env` file in the project root and add your secrets:
    ```bash
-   SECRET_KEY=replace-me
-   PAYMENT_API_KEY=replace-me
-   ADMIN_USERNAME=admin
-   ADMIN_PASSWORD=changeme
-   # Enable the Flask debugger locally (defaults to False if unset)
-   FLASK_DEBUG=True
-   # Only set to False when developing without HTTPS (defaults to True)
-   SESSION_COOKIE_SECURE=False
-   ```
-   The `.env` file is ignored by Git.
+    SECRET_KEY=replace-me
+    PAYMENT_API_KEY=replace-me
+    ADMIN_USERNAME=admin
+    ADMIN_PASSWORD=changeme
+    # Enable the Flask debugger locally (defaults to False if unset)
+    FLASK_DEBUG=True
+    # Only set to False when developing without HTTPS (defaults to True)
+    SESSION_COOKIE_SECURE=False
+    ```
+    The `.env` file is ignored by Git.
+
+    By default the application assumes a production environment:
+
+    - `SESSION_COOKIE_SECURE` is **True** so cookies are only sent over HTTPS.
+      When developing locally without HTTPS, override this in your `.env` as
+      shown above to allow testing over plain HTTP.
+    - `FLASK_DEBUG` is **False** to avoid leaking internal information. Set
+      `FLASK_DEBUG=True` in development to enable the debugger and auto reload.
 
 5. **Initialize the database**
    Run the helper script once to create `instance/paddlingen.db` and seed the administrator account specified above:
@@ -71,7 +79,8 @@ For production deployments run the app with **Gunicorn**:
 
 Ensure the environment variables from the **Setup** section are available. When deploying publicly,
 enable HTTPS and set `SESSION_COOKIE_SECURE=True` so session cookies are only sent over secure
-connections.
+connections. Leave `FLASK_DEBUG` unset (or set to `False`) so the interactive debugger is disabled in
+production.
 
 Any provider capable of running Python web apps works—services like Heroku or Render are common
 choices, or you can build a container image and run it with Docker.

--- a/config.py
+++ b/config.py
@@ -25,7 +25,12 @@ load_dotenv(override=True)
 
 # Helper -------------------------------------------------------------
 def _bool_from_env(name: str, default: bool = False) -> bool:
-    """Return a boolean from environment variable."""
+    """Return a boolean value from an environment variable.
+
+    This lets us control configuration with environment variables (like in a
+    `.env` file) without editing the code. If the variable is missing we fall
+    back to the provided default.
+    """
     value = os.getenv(name)
     if value is None:
         return default
@@ -90,8 +95,11 @@ WTF_CSRF_SECRET_KEY = SECRET_KEY
 
 # If set to True, the browser will only send the session cookie over a secure
 # HTTPS connection. This prevents the cookie from being stolen by eavesdroppers
-# on an insecure network (like public Wi-Fi). Must be False for local HTTP testing.
-# TODO: Set this to `True` for production deployment.
+# on an insecure network (like public Wi-Fi).
+#
+# We default this to True so production deployments are safe by default.
+# When developing locally without HTTPS, set `SESSION_COOKIE_SECURE=False`
+# in your environment (e.g. in `.env`) to allow testing over plain HTTP.
 SESSION_COOKIE_SECURE = _bool_from_env("SESSION_COOKIE_SECURE", default=True)
 
 # If set to True, it tells the browser not to allow JavaScript to access the
@@ -116,4 +124,7 @@ SESSION_COOKIE_SAMESITE = 'Lax'
 #   - It will show a detailed, interactive debugger in the browser if an error occurs.
 # WARNING: This MUST be set to `False` in a production environment, as the
 # interactive debugger can expose sensitive information.
+#
+# The setting defaults to False for safety. To enable the debugger during
+# development, export `FLASK_DEBUG=True` or add it to your `.env` file.
 DEBUG = _bool_from_env("FLASK_DEBUG", default=False)


### PR DESCRIPTION
## Summary
- secure session cookies by default and document how to loosen them for local development
- keep Flask's debugger off in production by default with guidance on enabling it locally
- explain configuration overrides in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d1a7baff88323b5003502b1b93a10