### PR TITLE
Add explanatory docstrings to tests

### DIFF
--- a/tests/test_admin_crud.py
+++ b/tests/test_admin_crud.py
@@ -6,6 +6,7 @@ def login(client):
 
 
 def test_admin_crud_flow(client):
+    """Add, update, and delete a booking to validate full CRUD so admins manage data reliably."""
     login(client)
 
     # Add a booking

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,9 +1,11 @@
 
 def test_home_page(client):
+    """Request the landing page and ensure it is publicly reachable."""
     res = client.get('/')
     assert res.status_code == 200
 
 
 def test_login_page(client):
+    """Confirm the login page renders so users can authenticate."""
     res = client.get('/login')
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- Clarify intent of public page tests for home and login routes
- Document admin CRUD workflow in test to illustrate add-update-delete operations

## Testing
- `pytest tests/test_public.py tests/test_admin_crud.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68910bb3450c8323af35760a48f02fff