### PR TITLE
Add authentication tests for admin and login routes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import os
 import pytest
+
+# Ensure the instance directory exists so the app's SQLite database can be created
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+os.makedirs(os.path.join(BASE_DIR, 'instance'), exist_ok=True)
+
 from main import app, db, User
 
 @pytest.fixture
@@ -8,7 +13,8 @@ def client():
         TESTING=True,
         SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
         WTF_CSRF_ENABLED=False,
-        SECRET_KEY='test'
+        SECRET_KEY='test',
+        WTF_CSRF_SECRET_KEY='test'
     )
     with app.app_context():
         db.drop_all()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,27 @@
+def test_admin_requires_login(client):
+    """Try to open the admin dashboard without logging in.
+
+    The test sends a GET request to '/admin' using the anonymous test client. The
+    @login_required decorator should stop anonymous users and respond with an
+    HTTP 302 redirect. The Location header in that redirect should include
+    '/login', which proves unauthenticated visitors are sent to the login page.
+    """
+    res = client.get('/admin')
+    assert res.status_code == 302
+    assert '/login' in res.headers['Location']
+
+
+def test_login_fails_with_wrong_password(client):
+    """Submit the login form with a bad password and check for failure.
+
+    A POST request is sent to '/login' using the correct username but the wrong
+    password. The app should not log the user in. Instead it re-renders the
+    login page with an error message. We assert the page loads (status code 200),
+    that the error text appears in the response body, and that we remain on the
+    '/login' URL.
+    """
+    res = client.post('/login', data={'username': 'admin', 'password': 'wrong'}, follow_redirects=True)
+    assert res.status_code == 200
+    page_text = res.get_data(as_text=True)
+    assert 'Felaktigt användarnamn eller lösenord' in page_text
+    assert res.request.path == '/login'


### PR DESCRIPTION
## Summary
- add tests verifying admin dashboard redirects to login when unauthenticated
- add tests checking login fails and shows error on wrong password
- ensure test setup creates instance folder and CSRF secret

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689258d694f883238dd225f84411e387