### PR TITLE
Add CLI commands for database management

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -1,58 +1,30 @@
 #!/usr/bin/env python3
-"""Utility script to reset and seed the local SQLite database."""
+"""Convenience wrapper around the database management CLI commands.
 
-import os
-import logging
-from app import create_app, db, User
+The real work of creating tables and seeding an administrator account is
+performed by custom `flask` command line interface (CLI) commands
+registered inside :mod:`app.__init__`.  Developers are encouraged to run
+those commands directly:
 
-# Application instance used for database operations
+    flask --app app init-db
+    flask --app app seed-admin
+
+Running this script simply executes both commands in sequence.  It is
+provided mainly for quick experiments or for environments where invoking
+the Flask CLI is inconvenient.
+"""
+
+from app import create_app, init_db_command, seed_admin_command
+
+# Build the application so that the CLI command functions have access to
+# the configured extensions (database, etc.).
 flask_application = create_app()
-
-# ---------------------------------------------------------------------------
-# LOGGING SETUP
-# ---------------------------------------------------------------------------
-logger = logging.getLogger(__name__)
-
-DATABASE_PATH = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "instance",
-    "paddlingen.db",
-)
-
-
-def init_db() -> None:
-    """Delete the old database file (if any) and create fresh tables."""
-    os.makedirs(os.path.dirname(DATABASE_PATH), exist_ok=True)
-
-    if os.path.exists(DATABASE_PATH):
-        os.remove(DATABASE_PATH)
-        logger.info("Removed old database file at %s.", DATABASE_PATH)
-
-    with flask_application.app_context():
-        db.create_all()
-        logger.info("Created new database schema at %s.", DATABASE_PATH)
-
-
-def seed_admin() -> None:
-    """Insert the initial admin user if it is missing."""
-    with flask_application.app_context():
-        admin_username = os.getenv("ADMIN_USERNAME")
-        admin_password = os.getenv("ADMIN_PASSWORD")
-
-        logger.debug("Admin username from environment: %s", admin_username)
-        logger.debug("Admin password from environment: %s", admin_password)
-
-        if User.query.filter_by(username=admin_username).first():
-            logger.info("Admin '%s' already exists—skipping.", admin_username)
-            return
-
-        admin_user_object = User(username=admin_username)
-        admin_user_object.set_password(admin_password)
-        db.session.add(admin_user_object)
-        db.session.commit()
-        logger.info("Created admin user '%s'.", admin_username)
 
 
 if __name__ == "__main__":
-    init_db()
-    seed_admin()
+    # The command functions expect an application context in order to
+    # interact with the database.  We create that context here and call
+    # the commands directly.
+    with flask_application.app_context():
+        init_db_command()
+        seed_admin_command()


### PR DESCRIPTION
## Summary
- register `flask init-db` and `flask seed-admin` CLI commands for easy database setup
- replace init_db.py with wrapper that invokes CLI commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4ab2e9808323a160f2bf7f214634