### PR TITLE
Add Alembic migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ A small Flask application for managing canoe rentals. The app lets visitors book
    pytest
    ```
 
+## Database migrations
+
+Paddlingen uses [Alembic](https://alembic.sqlalchemy.org/) to keep the
+database schema in sync with your models.
+
+1. **Create a migration** – whenever you change a model, ask Alembic to
+   generate a migration script:
+   ```bash
+   alembic revision --autogenerate -m "describe your change"
+   ```
+   The command inspects the `db` models and stores a new migration file in
+   `migrations/versions`.
+
+2. **Apply migrations** – run pending migrations to update the database to the
+   latest schema:
+   ```bash
+   alembic upgrade head
+   ```
+
+3. **Roll back** – undo the last migration if something went wrong:
+   ```bash
+   alembic downgrade -1
+   ```
+   You can replace `-1` with a specific revision identifier to roll back to an
+   exact point in history.
+
+For more background see the [Alembic tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html).
+
 ## Using PostgreSQL
 
 By default Paddlingen stores data in a local SQLite file.  SQLite is great for

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,39 @@
+# Alembic configuration file
+# Generated manually in absence of Alembic installation
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+# SQLAlchemy connection string; Alembic will override this from the Flask app.
+sqlalchemy.url = sqlite:///instance/paddlingen.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s: %(message)s

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration for Alembic.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,69 @@
+"""Alembic environment file for Paddlingen.
+
+This config uses the Flask application's SQLAlchemy metadata so that
+`alembic revision --autogenerate` works out of the box.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+
+# Add the application to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db  # noqa: E402
+
+# Load the Flask application and push an application context.  This gives
+# Alembic access to the SQLAlchemy metadata and database configuration.
+app = create_app()
+app.app_context().push()
+
+# Alembic Config object, which provides access to the values within the
+# alembic.ini file.
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Override the SQLAlchemy URL from the Flask app's configuration.
+config.set_main_option("sqlalchemy.url", str(app.config["SQLALCHEMY_DATABASE_URI"]))
+
+# Set target metadata for 'autogenerate'.
+target_metadata = db.metadata
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = db.engine
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,18 @@
+"""${message}
+
+Revision ID: ${revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.13.1
 blinker==1.9.0
 certifi==2025.4.26
 charset-normalizer==3.4.2


### PR DESCRIPTION
## Summary
- add Alembic to requirements and basic configuration
- set up migrations directory wired to Flask's SQLAlchemy metadata
- document how to create, apply, and roll back migrations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ec2c723e48323afe416e53f28ef47