### PR TITLE
Add docstrings for clarity across tests and utilities

### DIFF
--- a/app/util/db_models.py
+++ b/app/util/db_models.py
@@ -81,6 +81,13 @@ class PendingBooking(db.Model):
     status = db.Column(db.String(20), nullable=False, default='pending')
 
     def __repr__(self):
+        """Return a readable representation for debugging.
+
+        Returns:
+            str: String containing the row ID and the number of canoes
+                requested, e.g. ``"<PendingBooking 5 – 2 canoe(s)>"``.
+        """
+
         return f"<PendingBooking {self.id} – {self.canoe_count} canoe(s)>"
 
 

--- a/config.py
+++ b/config.py
@@ -25,12 +25,22 @@ load_dotenv(override=True)
 
 # Helper -------------------------------------------------------------
 def _bool_from_env(name: str, default: bool = False) -> bool:
-    """Return a boolean value from an environment variable.
+    """Return a boolean value read from an environment variable.
 
-    This lets us control configuration with environment variables (like in a
-    `.env` file) without editing the code. If the variable is missing we fall
-    back to the provided default.
+    This helper normalizes common truthy strings ("1", "true", "yes", etc.)
+    and falls back to ``default`` when the variable is missing.  It keeps
+    configuration parsing tidy and easy to understand for newcomers.
+
+    Args:
+        name (str): The environment variable to read.
+        default (bool, optional): Value to return if the variable is unset.
+            Defaults to ``False``.
+
+    Returns:
+        bool: ``True`` when the variable contains a truthy string,
+        otherwise ``False`` or the provided default.
     """
+
     value = os.getenv(name)
     if value is None:
         return default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,12 @@ def client():
     database.  By setting ``DATABASE_URL`` to the special SQLite memory URI we
     ensure the application's configuration picks up this transient database
     instead of whatever the developer might have configured locally.
+
+    Yields:
+        flask.testing.FlaskClient: A client instance with a fresh application
+            and database for each test case.
     """
+
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
     flask_application = create_app()
     flask_application.config.update(

--- a/tests/test_admin_crud.py
+++ b/tests/test_admin_crud.py
@@ -2,11 +2,46 @@ from app import db, RentForm
 
 
 def login(client):
-    return client.post('/login', data={'username': 'admin', 'password': 'password'}, follow_redirects=True)
+    """Helper that logs the test client in as the administrator.
+
+    This function simulates submitting the login form so that subsequent
+    requests are authenticated.  It is intentionally tiny but having a
+    docstring here helps new contributors understand what happens.
+
+    Args:
+        client (flask.testing.FlaskClient): The Flask test client used to send
+            the POST request.
+
+    Returns:
+        werkzeug.wrappers.Response: The response object returned by the login
+            request.  Tests generally ignore it but it can be inspected if
+            needed.
+    """
+
+    return client.post(
+        '/login',
+        data={'username': 'admin', 'password': 'password'},
+        follow_redirects=True,
+    )
 
 
 def test_admin_crud_flow(client):
-    """Admin adds a booking, edits it, then deletes it to prove the CRUD cycle works."""
+    """Verify that the admin interface supports the full CRUD cycle.
+
+    The test logs in, creates a booking, edits that booking, and finally
+    deletes it.  Each step asserts that the database and HTTP responses
+    reflect the expected state, proving that Create, Read, Update and Delete
+    all behave correctly.
+
+    Args:
+        client (flask.testing.FlaskClient): Authorized Flask test client
+            provided by the ``client`` fixture.
+
+    Returns:
+        None: Pytest verifies behaviour using assertions rather than a return
+            value.
+    """
+
     login(client)
 
     # Add a booking


### PR DESCRIPTION
## Summary
- document helper login function and full admin CRUD test
- clarify pending booking representation and environment parsing helper
- document pytest client fixture setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f01ea4f0083238d5ba55c24730144